### PR TITLE
Revert "Update challenge 115 tests to match instructions"

### DIFF
--- a/spec/115-spec.js
+++ b/spec/115-spec.js
@@ -9,8 +9,8 @@ let items = [
 
 // assumes 2021-02-04 code challenge date.  This will need to be updated every cohort.
 let oldItems = [
-  'Soy milk',
-  'Sirloin',
+  { name: 'Soy milk', expiryDate: '2021-01-01' },
+  { name: 'Sirloin', expiryDate: '2021-01-05' }
 ];
 
 describe("Challenge 115:", () => {


### PR DESCRIPTION
Reverting this because I don't think it can propagate to people who have already done the challenge, and having 2 version of the tests around is confusing.